### PR TITLE
Update deprecated temperature units

### DIFF
--- a/custom_components/dewpoint/manifest.json
+++ b/custom_components/dewpoint/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/miguelangel-nubla/home-assistant-dewpoint",
   "dependencies": [],
   "codeowners": ["@miguelangel-nubla"],
-  "requirements": ["psychrolib==2.1.0"]
+  "requirements": ["psychrolib==2.1.0"],
+  "version": "1.0.0"
 }

--- a/custom_components/dewpoint/sensor.py
+++ b/custom_components/dewpoint/sensor.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.core import callback
 from homeassistant.const import (
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_SENSORS,
+    UnitOfTemperature, ATTR_FRIENDLY_NAME, ATTR_ENTITY_ID, CONF_SENSORS,
     EVENT_HOMEASSISTANT_START, ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE)
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.event import async_track_state_change
@@ -105,7 +105,7 @@ class DewPointSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @callback
     def get_dry_temp(self, entity):
@@ -124,13 +124,13 @@ class DewPointSensor(Entity):
             return None
 
         # convert to celsius if necessary
-        if unit == TEMP_FAHRENHEIT:
+        if unit == UnitOfTemperature.FAHRENHEIT:
             return util.temperature.fahrenheit_to_celsius(temp)
-        if unit == TEMP_CELSIUS:
+        if unit == UnitOfTemperature.CELSIUS:
             return temp
         _LOGGER.error("Temp sensor %s has unsupported unit: %s (allowed: %s, "
-                      "%s)", state.entity_id, unit, TEMP_CELSIUS,
-                      TEMP_FAHRENHEIT)
+                      "%s)", state.entity_id, unit, UnitOfTemperature.CELSIUS,
+                      UnitOfTemperature.FAHRENHEIT)
 
         try:
             return self.hass.config.units.temperature(


### PR DESCRIPTION
Changed from TEMP_CELSIUS and TEMP_FAHRENHEIT constants (removed in HA 2025.1) to UnitOfTemperature enumerator.
See https://developers.home-assistant.io/blog/2022/10/26/new-unit-enumerators/